### PR TITLE
fix `fit.list()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: trending
 Title: Model Temporal Trends
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: 
     c(
       person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# trending (development version)
+
+* Fix a bug in `fit.list()` that was causing it to sometimes fail when used
+  within other functions.
+
 # trending 0.1.0
 
 ## Breaking changes

--- a/tests/testthat/test-lists.R
+++ b/tests/testthat/test-lists.R
@@ -17,6 +17,11 @@ test_that("lm_model", {
   list_pred_nmd <- predict(list_fit_nmd, mtcars)
   list_pred_from_model <- predict(list(l=l, nb=nb), mtcars)
 
+  # test for #22 fix
+  f <- function(y) fit(list(l, nb), y)
+  expect_identical(f(mtcars)$errors, list(NULL, NULL))
+
+
   expect_equal(get_warnings(list_fit), list(NULL, NULL))
   expect_equal(get_warnings(list_pred_from_model), list(l=NULL, nb=NULL))
   expect_equal(get_errors(list_fit), list(NULL, NULL))


### PR DESCRIPTION
This fixes #22, which should allow us to fix trendbreaker a little easier. It is very hacky and all of the NSE really needs a more detailed look but it is atleast better than the current implementation (hopefully).